### PR TITLE
Compare the business end of the path ...

### DIFF
--- a/lib/highlight-cov-view.coffee
+++ b/lib/highlight-cov-view.coffee
@@ -48,7 +48,7 @@ class HighlightCovView extends View
       return
 
     parse infoFilePath, (err, data) =>
-      fileData = (data.filter (f) => (filePath.substr(0, f.file.length) == f.file))[0]
+      fileData = (data.filter (f) => (filePath.substr(filePath.length - f.file.length) == f.file))[0]
       if not fileData
         console.log 'no coverage info found for this file'
         return


### PR DESCRIPTION
We want to match up paths by comparing the business end (including the extension) of the editor and lcov files:

"/Users/joe/Projects/test/src/server/app.coffee" (as open in the editor)
should match to
"src/server/app.coffee" (as found in the lcov.info file)

The previous implementation would try to match "/Users/joe/Projects/t" to "src/server/app.coffee" since it matches from the start of the string.
